### PR TITLE
TEST_CI: Replace manual dep installs in workflows with tox environments

### DIFF
--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -30,36 +30,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: min-versions-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-minimum-versions
-        run: |
-          uv pip install \
-            pipdeptree tox virtualenv setuptools tzdata \
-            pandas==1.3.4 \
-            polars==0.20.4 \
-            numpy==1.21.4 \
-            pyarrow==13.0.0 \
-            "pyarrow-stubs<17" \
-            scipy==1.7.3 \
-            scikit-learn==1.1.0 \
-            duckdb==1.1 \
-            --system
-      - name: install-reqs
-        run: |
-          uv pip install -e . --group tests
-      - name: show-deps
-        run: uv pip freeze
-      - name: Assert dependencies
-        run: |
-          DEPS=$(uv pip freeze)
-          echo "$DEPS" | grep 'pandas==1.3.4'
-          echo "$DEPS" | grep 'polars==0.20.4'
-          echo "$DEPS" | grep 'numpy==1.21.4'
-          echo "$DEPS" | grep 'pyarrow==13.0.0'
-          echo "$DEPS" | grep 'scipy==1.7.3'
-          echo "$DEPS" | grep 'scikit-learn==1.1.0'
-          echo "$DEPS" | grep 'duckdb==1.1'
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb
+        run: uvx --with tox-uv tox -e minimum_versions
 
   pretty_old_versions:
     strategy:
@@ -78,37 +50,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: pretty-old-versions-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-pretty-old-versions
-        run: |
-          uv pip install \
-            pipdeptree tox virtualenv setuptools tzdata \
-            pandas==1.4.1 \
-            polars==0.20.4 \
-            numpy==1.22.0 \
-            pyarrow==14.0.0 \
-            "pyarrow-stubs<17" \
-            scipy==1.8.0 \
-            scikit-learn==1.1.0 \
-            duckdb==1.2 \
-            --system
-      - name: install-reqs
-        run: uv pip install -e . --group tests
-      - name: show-deps
-        run: uv pip freeze
-      - name: show-deptree
-        run: pipdeptree
-      - name: Assert pretty old versions dependencies
-        run : |
-          DEPS=$(uv pip freeze)
-          echo "$DEPS" | grep 'pandas==1.4.1'
-          echo "$DEPS" | grep 'polars==0.20.4'
-          echo "$DEPS" | grep 'numpy==1.22.0'
-          echo "$DEPS" | grep 'pyarrow==14.0.0'
-          echo "$DEPS" | grep 'scipy==1.8.0'
-          echo "$DEPS" | grep 'scikit-learn==1.1.0'
-          echo "$DEPS" | grep 'duckdb==1.2'
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb
+        run: uvx --with tox-uv tox -e pretty_old_versions
 
   not_so_old_versions:
     strategy:
@@ -127,25 +70,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: not-so-old-versions-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-not-so-old-versions
-        run: uv pip install tox virtualenv setuptools pandas==2.0.3 polars==0.20.8 numpy==1.24.4 pyarrow==15.0.0 "pyarrow-stubs<17" scipy==1.8.0 scikit-learn==1.3.0 duckdb==1.3 dask[dataframe]==2024.10 tzdata
-      - name: install-reqs
-        run: uv pip install -e . --group tests
-      - name: show-deps
-        run: uv pip freeze
-      - name: Assert not so old versions dependencies
-        run : |
-          DEPS=$(uv pip freeze)
-          echo "$DEPS" | grep 'pandas==2.0.3'
-          echo "$DEPS" | grep 'polars==0.20.8'
-          echo "$DEPS" | grep 'numpy==1.24.4'
-          echo "$DEPS" | grep 'pyarrow==15.0.0'
-          echo "$DEPS" | grep 'scipy==1.8.0'
-          echo "$DEPS" | grep 'scikit-learn==1.3.0'
-          echo "$DEPS" | grep 'dask==2024.10'
-          echo "$DEPS" | grep 'duckdb==1.3'
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow --constructors=pandas,pyarrow,polars[eager],polars[lazy],dask,duckdb
+        run: uvx --with tox-uv tox -e not_so_old_versions
 
   nightlies:
     strategy:
@@ -164,42 +90,5 @@ jobs:
           enable-cache: "true"
           cache-suffix: nightlies-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group tests
-      - name: install polars pre-release
-        run: |
-          uv pip uninstall polars
-          uv pip install -U --pre polars
-      - name: install-pandas-nightly
-        run: |
-          uv pip uninstall pandas
-          uv pip install pandas --pre --index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -U
-      - name: install pyarrow nightly
-        run: |
-          uv pip uninstall pyarrow
-          uv pip install pyarrow --pre --index https://pypi.fury.io/arrow-nightlies/ -U
-      - name: install numpy nightly
-        run: |
-          uv pip uninstall numpy
-          uv pip install numpy --pre --index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple -U
-      - name: install dask
-        run: |
-          uv pip uninstall dask dask-expr
-          uv pip install "git+https://github.com/dask/dask[dataframe]"
-      - name: install duckdb nightly
-        run: |
-          uv pip uninstall duckdb
-          uv pip install -U --pre duckdb
-      - name: show-deps
-        run: uv pip freeze
-      - name: Assert nightlies dependencies
-        run: |
-          DEPS=$(uv pip freeze)
-          echo "$DEPS" | grep -E 'pandas.*(dev|rc|\+)'
-          echo "$DEPS" | grep 'pyarrow.*dev'
-          echo "$DEPS" | grep 'numpy.*dev'
-          echo "$DEPS" | grep 'dask.*@'
       - name: Run pytest
-        run: |
-          pytest tests --cov=narwhals --cov=tests --cov-fail-under=50 --runslow \
-          --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb
+        run: uvx --with tox-uv tox -e nightlies

--- a/.github/workflows/extremes.yml
+++ b/.github/workflows/extremes.yml
@@ -6,7 +6,6 @@ on:
 env:
   PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
-  UV_SYSTEM_PYTHON: 1
 
 permissions:
   contents: read

--- a/.github/workflows/pytest-ibis.yml
+++ b/.github/workflows/pytest-ibis.yml
@@ -7,7 +7,6 @@ on:
 env:
   PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
-  UV_SYSTEM_PYTHON: 1
 
 permissions:
   contents: read

--- a/.github/workflows/pytest-ibis.yml
+++ b/.github/workflows/pytest-ibis.yml
@@ -13,7 +13,6 @@ permissions:
   contents: read
 
 jobs:
-
   pytest-ibis-constructor:
     if: github.head_ref != 'bump-version'
     strategy:
@@ -32,14 +31,5 @@ jobs:
           enable-cache: "true"
           cache-suffix: ibis-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group core-tests
-      - name: install ibis
-        run: |
-          # Temporary pin until it's fixed upstream
-          uv pip install "sqlglot<28.6"
-          uv pip install -e ".[ibis]"
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --constructors ibis
+        run: uvx --with tox-uv tox -e pytest_ibis

--- a/.github/workflows/pytest-modin.yml
+++ b/.github/workflows/pytest-modin.yml
@@ -13,7 +13,6 @@ permissions:
   contents: read
 
 jobs:
-
   pytest-modin-constructor:
     if: github.head_ref != 'bump-version'
     strategy:
@@ -32,12 +31,5 @@ jobs:
           enable-cache: "true"
           cache-suffix: modin-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group core-tests
-      - name: install modin
-        run: |
-          uv pip install -e ".[modin]"
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --constructors modin[pyarrow]
+        run: uvx --with tox-uv tox -e pytest_modin

--- a/.github/workflows/pytest-modin.yml
+++ b/.github/workflows/pytest-modin.yml
@@ -7,7 +7,6 @@ on:
 env:
   PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
-  UV_SYSTEM_PYTHON: 1
 
 permissions:
   contents: read

--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -15,7 +15,6 @@ on:
 env:
   PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
-  UV_SYSTEM_PYTHON: 1
 
 permissions:
   contents: read

--- a/.github/workflows/pytest-pyspark.yml
+++ b/.github/workflows/pytest-pyspark.yml
@@ -10,7 +10,7 @@ on:
       - tests/frame/*sink*.py
   workflow_call:
   schedule:
-    - cron: 0 12 * * 0  # Sunday at mid-day
+    - cron: 0 12 * * 0 # Sunday at mid-day
 
 env:
   PY_COLORS: 1
@@ -39,15 +39,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: pyspark-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group core-tests
-      - name: install pyspark
-        run: uv pip install -e ".[pyspark]"
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --cov=narwhals/_spark_like --cov-fail-under=95 --runslow --constructors pyspark
-
+        run: uvx --with tox-uv tox -e pytest_pyspark
 
   pytest-pyspark-min-version-constructor:
     if: github.head_ref != 'bump-version'
@@ -67,14 +60,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: pyspark-min-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group core-tests --system
-      - name: install pyspark (min version)
-        run: uv pip install "pyspark==3.5.0" --system
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --constructors pyspark
+        run: uvx --with tox-uv tox -e pytest_pyspark_min_versions
 
   pytest-pyspark-connect-constructor:
     if: github.head_ref != 'bump-version'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,6 @@ on:
 env:
   PY_COLORS: 1
   PYTEST_ADDOPTS: "--numprocesses=logical"
-  UV_SYSTEM_PYTHON: 1
 
 permissions:
   contents: read

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,14 +31,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: pytest-310-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e ".[pandas,polars,pyarrow]" --group tests
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=75 --constructors=pandas,pyarrow,polars[eager],polars[lazy]
-      - name: install-test-plugin
-        run: uv pip install -e test-plugin/.
+        run: uvx --with tox-uv tox -e pytest_310
 
   pytest-windows:
     if: github.head_ref != 'bump-version'
@@ -58,16 +52,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: pytest-windows-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        # we are not testing pyspark, modin, or dask on Windows here because nobody got time for that
-        run: uv pip install -e "." --group core-tests --group extra
-      - name: install-test-plugin
-        run: uv pip install -e test-plugin/.
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: |
-          pytest tests --cov=narwhals --cov=tests --runslow --cov-fail-under=95 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe --durations=30
+        run: uvx --with tox-uv tox -e pytest_windows
 
   pytest-full-coverage:
     if: github.head_ref != 'bump-version'
@@ -92,18 +78,12 @@ jobs:
           enable-cache: "true"
           cache-suffix: pytest-full-coverage-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e ".[dask]" --group core-tests --group extra
-      - name: install-test-plugin
-        run: uv pip install -e test-plugin/.
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --cov-fail-under=100 --runslow --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe --durations=30
+        run: uvx --with tox-uv tox -e pytest_full_coverage
       - name: Run doctests
         # reprs differ between versions, so we only run doctests on the latest Python
         if: matrix.python-version == '3.13'
-        run: pytest narwhals --doctest-modules
+        run: uvx --with tox-uv tox -e pytest_doctests
 
   # Test against smaller dependency set, used e.g. on Gentoo.
   pytest-narrower-dependencies:
@@ -124,25 +104,12 @@ jobs:
           enable-cache: "true"
           cache-suffix: pytest-narrower-deps-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: |
-          uv pip install -e ".[pandas]" --group tests
-          uv pip freeze
       - name: Run pytest (pandas and pandas[nullable])
-        run: pytest tests --runslow --constructors=pandas,pandas[nullable]
-      - name: install-more-reqs
-        run: |
-          uv pip install -U pyarrow
-          uv pip freeze
+        run: uvx --with tox-uv tox -e pytest_narrower_pandas
       - name: Run pytest (pandas[pyarrow] and pyarrow)
-        run: pytest tests --runslow --constructors=pandas[pyarrow],pyarrow
-      - name: install-polars
-        run: |
-          uv pip uninstall pandas pyarrow
-          uv pip install polars
-          uv pip freeze
+        run: uvx --with tox-uv tox -e pytest_narrower_pyarrow
       - name: Run pytest (polars)
-        run: pytest tests --runslow --constructors=polars[eager],polars[lazy]
+        run: uvx --with tox-uv tox -e pytest_narrower_polars
 
   python-314:
     if: github.head_ref != 'bump-version'
@@ -162,12 +129,8 @@ jobs:
           enable-cache: "true"
           cache-suffix: python-314-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group tests pandas polars pyarrow duckdb sqlframe
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe --cov-fail-under=50
+        run: uvx --with tox-uv tox -e python_314
 
   python-314t:
     if: github.head_ref != 'bump-version'
@@ -177,7 +140,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
-        PYTHON_GIL: 0
+      PYTHON_GIL: 0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -189,9 +152,5 @@ jobs:
           enable-cache: "true"
           cache-suffix: python-314t-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: install-reqs
-        run: uv pip install -e . --group tests --pre pandas pyarrow
-      - name: show-deps
-        run: uv pip freeze
       - name: Run pytest
-        run: pytest tests --cov=narwhals --cov=tests --runslow --durations=30 --constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow --cov-fail-under=50
+        run: uvx --with tox-uv tox -e python_314t

--- a/.github/workflows/random_ci_pytest.yml
+++ b/.github/workflows/random_ci_pytest.yml
@@ -29,15 +29,5 @@ jobs:
           enable-cache: "true"
           cache-suffix: pytest-random-ci-${{ matrix.python-version }}
           cache-dependency-glob: "pyproject.toml"
-      - name: generate-random-versions
-        run: python utils/generate_random_versions.py
-      - name: install-random-versions
-        run: uv pip install -r random-requirements.txt --system
-      - name: install-narwhals
-        run: uv pip install -e . --group tests --system
-      - name: show versions
-        run: uv pip freeze
       - name: Run pytest
-        run: |
-            pytest tests --cov=narwhals --cov=tests --cov-fail-under=75 \
-            --constructors=pandas,pyarrow,polars[eager],polars[lazy]
+        run: uvx --with tox-uv tox -e random_versions

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage.xml
 .pytest_cache/
 .mypy_cache
 
+# Test artifacts
+random-requirements.txt
+
 # Documentation
 site/
 todo.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,19 @@ If you add code that should be tested, please add tests.
   - To run tests using `cudf.pandas`, run `NARWHALS_DEFAULT_CONSTRUCTORS=pandas python -m cudf.pandas -m pytest`
   - To run tests using `polars[gpu]`, run `NARWHALS_POLARS_GPU=1 pytest --constructors=polars[lazy]`
 
+#### Reproducing CI environments locally
+
+CI jobs that test specific dependency versions (minimum versions, older versions, nightlies, etc.) are defined as tox environments in `tox.toml`. You can reproduce any of them locally with:
+
+```terminal
+uvx --with tox-uv tox -e minimum_versions
+uvx --with tox-uv tox -e pretty_old_versions
+uvx --with tox-uv tox -e not_so_old_versions
+uvx --with tox-uv tox -e random_versions
+```
+
+`uvx` runs tox without a permanent install. Each environment creates an isolated virtualenv with the exact pinned dependencies defined in `tox.toml`.
+
 ### General considerations
 
 In general we assume that dataframes are used to store and process columnar data. Therefore:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,6 +281,9 @@ filterwarnings = [
   "ignore:.*is_sparse is deprecated and will be removed in a future version.*:DeprecationWarning:pyarrow",
 
   "ignore:.*invalid value encountered in cast:RuntimeWarning:pandas",
+  # macOS raises these when applying trig functions to NaN values
+  "ignore:.*invalid value encountered in cos:RuntimeWarning:pandas",
+  "ignore:.*invalid value encountered in sin:RuntimeWarning:pandas",
   "ignore:.*The behavior of DataFrame concatenation with empty or all-NA entries is deprecated:FutureWarning",
 
   # raised internally by Dask

--- a/tests/repr_test.py
+++ b/tests/repr_test.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+from unittest.mock import patch
+
 import pytest
 
 import narwhals as nw
@@ -71,7 +74,10 @@ def test_repr(request: pytest.FixtureRequest) -> None:
     assert result == expected
     # Make something wider than the terminal size
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["fdaf" * 100, "fda", "cf"]})
-    result = nw.from_native(duckdb.table("df")).__repr__()
+    with patch(
+        "narwhals._utils.os.get_terminal_size", return_value=os.terminal_size((80, 24))
+    ):
+        result = nw.from_native(duckdb.table("df")).__repr__()
     expected = (
         "┌───────────────────────────────────────┐\n"
         "|          Narwhals LazyFrame           |\n"

--- a/tox.toml
+++ b/tox.toml
@@ -1,0 +1,355 @@
+[env_run_base]
+runner = "uv-venv-runner"
+dependency_groups = ["tests"]
+commands_pre = [["uv", "pip", "freeze"]]
+pass_env = ["*"]
+
+[env.minimum_versions]
+basepython = "python3.10"
+deps = [
+  "setuptools",
+  "tzdata",
+  "pandas==1.3.4",
+  "polars==0.20.4",
+  "numpy==1.21.4",
+  "pyarrow==13.0.0",
+  "pyarrow-stubs<17",
+  "scipy==1.7.3",
+  "scikit-learn==1.1.0",
+  "duckdb==1.1",
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=50",
+    "--runslow",
+    "--constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb"
+  ],
+]
+
+[env.pretty_old_versions]
+basepython = "python3.10"
+deps = [
+  "pipdeptree",
+  "setuptools",
+  "tzdata",
+  "pandas==1.4.1",
+  "polars==0.20.4",
+  "numpy==1.22.0",
+  "pyarrow==14.0.0",
+  "pyarrow-stubs<17",
+  "scipy==1.8.0",
+  "scikit-learn==1.1.0",
+  "duckdb==1.2",
+]
+commands_pre = [["uv", "pip", "freeze"], ["pipdeptree"]]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=50",
+    "--runslow",
+    "--constructors=pandas,pyarrow,polars[eager],polars[lazy],duckdb"
+  ],
+]
+
+[env.not_so_old_versions]
+basepython = "python3.10"
+deps = [
+  "setuptools",
+  "tzdata",
+  "pandas==2.0.3",
+  "polars==0.20.8",
+  "numpy==1.24.4",
+  "pyarrow==15.0.0",
+  "pyarrow-stubs<17",
+  "scipy==1.8.0",
+  "scikit-learn==1.3.0",
+  "duckdb==1.3",
+  "dask[dataframe]==2024.10",
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=50",
+    "--runslow",
+    "--constructors=pandas,pyarrow,polars[eager],polars[lazy],dask,duckdb"
+  ],
+]
+
+[env.nightlies]
+basepython = "python3.12"
+commands_pre = [
+  ["uv", "pip", "uninstall", "polars"],
+  ["uv", "pip", "install", "-U", "--pre", "polars"],
+  ["uv", "pip", "uninstall", "pandas"],
+  [
+    "uv",
+    "pip",
+    "install",
+    "pandas",
+    "--pre",
+    "--index",
+    "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple",
+    "-U"
+  ],
+  ["uv", "pip", "uninstall", "pyarrow"],
+  [
+    "uv",
+    "pip",
+    "install",
+    "pyarrow",
+    "--pre",
+    "--index",
+    "https://pypi.fury.io/arrow-nightlies/",
+    "-U"
+  ],
+  ["uv", "pip", "uninstall", "numpy"],
+  [
+    "uv",
+    "pip",
+    "install",
+    "numpy",
+    "--pre",
+    "--index",
+    "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple",
+    "-U"
+  ],
+  ["uv", "pip", "uninstall", "dask", "dask-expr"],
+  ["uv", "pip", "install", "git+https://github.com/dask/dask[dataframe]"],
+  ["uv", "pip", "uninstall", "duckdb"],
+  ["uv", "pip", "install", "-U", "--pre", "duckdb"],
+  ["uv", "pip", "freeze"],
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=50",
+    "--runslow",
+    "--constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb"
+  ],
+]
+
+[env.pytest_310]
+basepython = "python3.10"
+extras = ["pandas", "polars", "pyarrow"]
+commands_pre = [
+  ["uv", "pip", "install", "-e", "{toxinidir}/test-plugin"],
+  ["uv", "pip", "freeze"],
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=75",
+    "--constructors=pandas,pyarrow,polars[eager],polars[lazy]"
+  ],
+]
+
+[env.pytest_windows]
+dependency_groups = ["core-tests", "extra"]
+commands_pre = [
+  ["uv", "pip", "install", "-e", "{toxinidir}/test-plugin"],
+  ["uv", "pip", "freeze"],
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=95",
+    "--runslow",
+    "--constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe",
+    "--durations=30"
+  ],
+]
+
+[env.pytest_full_coverage]
+extras = ["dask"]
+dependency_groups = ["core-tests", "extra"]
+commands_pre = [
+  ["uv", "pip", "install", "-e", "{toxinidir}/test-plugin"],
+  ["uv", "pip", "freeze"],
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=100",
+    "--runslow",
+    "--constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],dask,duckdb,sqlframe",
+    "--durations=30"
+  ],
+]
+
+[env.pytest_doctests]
+extras = ["dask"]
+dependency_groups = ["core-tests", "extra"]
+commands_pre = [
+  ["uv", "pip", "install", "-e", "{toxinidir}/test-plugin"],
+  ["uv", "pip", "freeze"],
+]
+commands = [
+  ["pytest", "narwhals", "--doctest-modules"],
+]
+
+[env.pytest_narrower_pandas]
+basepython = "python3.13"
+extras = ["pandas"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--runslow",
+    "--constructors=pandas,pandas[nullable]"
+  ],
+]
+
+[env.pytest_narrower_pyarrow]
+basepython = "python3.13"
+extras = ["pandas", "pyarrow"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--runslow",
+    "--constructors=pandas[pyarrow],pyarrow"
+  ],
+]
+
+[env.pytest_narrower_polars]
+basepython = "python3.13"
+extras = ["polars"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--runslow",
+    "--constructors=polars[eager],polars[lazy]"
+  ],
+]
+
+[env.python_314]
+basepython = "python3.14"
+deps = ["pandas", "polars", "pyarrow", "duckdb", "sqlframe"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--runslow",
+    "--durations=30",
+    "--constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow,polars[eager],polars[lazy],duckdb,sqlframe",
+    "--cov-fail-under=50"
+  ],
+]
+
+[env.python_314t]
+basepython = "python3.14t"
+pip_pre = true
+deps = ["pandas", "pyarrow"]
+set_env = { PYTHON_GIL = "0" }
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--runslow",
+    "--durations=30",
+    "--constructors=pandas,pandas[nullable],pandas[pyarrow],pyarrow",
+    "--cov-fail-under=50"
+  ],
+]
+
+[env.pytest_ibis]
+basepython = "python3.13"
+extras = ["ibis"]
+dependency_groups = ["core-tests"]
+deps = ["sqlglot<28.6"]  # temporary pin until fixed upstream
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--constructors",
+    "ibis"
+  ],
+]
+
+[env.pytest_modin]
+basepython = "python3.13"
+extras = ["modin"]
+dependency_groups = ["core-tests"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--constructors",
+    "modin[pyarrow]"
+  ],
+]
+
+[env.pytest_pyspark]
+basepython = "python3.11"
+extras = ["pyspark"]
+dependency_groups = ["core-tests"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals/_spark_like",
+    "--cov-fail-under=95",
+    "--runslow",
+    "--constructors",
+    "pyspark"
+  ],
+]
+
+[env.pytest_pyspark_min_versions]
+basepython = "python3.11"
+dependency_groups = ["core-tests"]
+deps = ["pyspark==3.5.0"]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--constructors",
+    "pyspark"
+  ],
+]
+
+[env.random_versions]
+basepython = "python3.10"
+dependency_groups = ["tests"]
+commands_pre = [
+  ["python", "utils/generate_random_versions.py"],
+  ["uv", "pip", "install", "-r", "{toxinidir}/random-requirements.txt"],
+  ["uv", "pip", "freeze"],
+]
+commands = [
+  [
+    "pytest",
+    { replace = "posargs", default = ["tests"], extend = true },
+    "--cov=narwhals",
+    "--cov=tests",
+    "--cov-fail-under=75",
+    "--constructors=pandas,pyarrow,polars[eager],polars[lazy]"
+  ],
+]

--- a/tox.toml
+++ b/tox.toml
@@ -87,6 +87,7 @@ commands = [
 
 [env.nightlies]
 basepython = "python3.12"
+allowlist_externals = ["bash"]
 commands_pre = [
   ["uv", "pip", "uninstall", "polars"],
   ["uv", "pip", "install", "-U", "--pre", "polars"],
@@ -128,6 +129,10 @@ commands_pre = [
   ["uv", "pip", "uninstall", "duckdb"],
   ["uv", "pip", "install", "-U", "--pre", "duckdb"],
   ["uv", "pip", "freeze"],
+  ["bash", "-c", "uv pip freeze | grep -E 'pandas.*(dev|rc|\\+)'"],
+  ["bash", "-c", "uv pip freeze | grep 'pyarrow.*dev'"],
+  ["bash", "-c", "uv pip freeze | grep 'numpy.*dev'"],
+  ["bash", "-c", "uv pip freeze | grep 'dask.*@'"],
 ]
 commands = [
   [


### PR DESCRIPTION
Add tox.toml defining all CI environments and update all workflows to delegate to `uvx --with tox-uv tox -e <env>`, removing duplicated install steps from CI yaml files.

